### PR TITLE
Change trigger word to Athena

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository provides a simple voice-enabled interface for [Claude Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/overview).
 
-The script `voice_to_claude_code.py` listens for a trigger word (default `"claude"`) and sends your spoken request to Claude Code, then plays the response using OpenAI TTS.
+The script `voice_to_claude_code.py` listens for a trigger word (default `"Athena"`) and sends your spoken request to Claude Code, then plays the response using OpenAI TTS.
 
 This project is forked from [indydevdan's `claude-code-is-programmable`](https://github.com/indydevdan/claude-code-is-programmable). It was trimmed using OpenAI Codex to focus on the voice agent for Claude Code.
 

--- a/voice_to_claude_code.py
+++ b/voice_to_claude_code.py
@@ -47,8 +47,8 @@ Run the script:
 ./voice_to_claude_code.py
 ```
 
-Speak to the assistant using the trigger word "claude" in your query.
-For example: "Hey claude, create a simple hello world script"
+Speak to the assistant using the trigger word "Athena" in your query.
+For example: "Hey Athena, create a simple hello world script"
 
 Press Ctrl+C to exit.
 """
@@ -79,7 +79,7 @@ from RealtimeSTT import AudioToTextRecorder
 import logging
 
 # Configuration - default values
-TRIGGER_WORDS = ["claude", "cloud", "sonnet", "sonny"]  # List of possible trigger words
+TRIGGER_WORDS = ["athena"]  # List of possible trigger words
 STT_MODEL = "small.en"  # Options: tiny.en, base.en, small.en, medium.en, large-v2
 TTS_VOICE = "nova"  # Options: alloy, echo, fable, onyx, nova, shimmer
 DEFAULT_CLAUDE_TOOLS = [


### PR DESCRIPTION
## Summary
- replace default trigger word with `Athena`
- update README and usage text

No tests run because pytest is not installed.
